### PR TITLE
Open an initial connection before speedtesting

### DIFF
--- a/speedtest_cloudflare_cli/core/speedtest.py
+++ b/speedtest_cloudflare_cli/core/speedtest.py
@@ -23,7 +23,7 @@ from rich.progress import (
 from speedtest_cloudflare_cli.models import metadata, result
 
 CHUNK_SIZE = 1024 * 1024
-PING_HOST = "google.com"
+PING_HOST = "1.1.1.1"
 PING_COUNT = 3
 PING_TIMEOUT = 3
 

--- a/speedtest_cloudflare_cli/core/speedtest.py
+++ b/speedtest_cloudflare_cli/core/speedtest.py
@@ -49,8 +49,8 @@ def track_progress(silent: bool = False) -> Generator[Progress, None, None]:
 def _fallback_ping() -> float | str:
     # Try system ping
     try:
-        out = subprocess.check_output(
-            ["ping", "-c", str(PING_COUNT), "-W", str(PING_TIMEOUT), PING_HOST],
+        out = subprocess.check_output(  # noqa: S603
+            ["ping", "-c", str(PING_COUNT), "-W", str(PING_TIMEOUT), PING_HOST],  # noqa: S607
             stderr=subprocess.DEVNULL,
             text=True,
         )

--- a/speedtest_cloudflare_cli/core/speedtest.py
+++ b/speedtest_cloudflare_cli/core/speedtest.py
@@ -102,7 +102,7 @@ class SpeedTest:
 
     def _http_latency(self, **kwargs):
         start = time.perf_counter()
-        client().head(f"https://{PING_HOST}", **kwargs)
+        client().head(f"https://{PING_HOST}", **kwargs, headers={"Connection": "Close"})
         return (time.perf_counter() - start) * 1000
 
 

--- a/speedtest_cloudflare_cli/core/speedtest.py
+++ b/speedtest_cloudflare_cli/core/speedtest.py
@@ -84,6 +84,10 @@ class SpeedTest:
         if self._ping_thread.is_alive():
             self._ping_thread.join()
 
+    def _init_connection(self) -> None:
+        """Opens a connection to the server and keeps it alive for subsequent requests."""
+        client().get(f"{self.url}/__down", params={"bytes": 0})
+
     def _download(self, progress: Progress | None = None, task: TaskID | None = None):
         """Download data in streaming chunks to keep the HTTP connection alive."""
         with client().stream("GET", f"{self.url}/__down", params={"bytes": self.download_size}) as response:
@@ -134,6 +138,9 @@ class SpeedTest:
         jitter = 0
         times_to_process = []
         jitters = []
+
+        self._init_connection()
+
         if progress:
             task = progress.add_task("", total=size_to_process * self.attempts)
         for _ in range(self.attempts):

--- a/tests/core/test_speedtest.py
+++ b/tests/core/test_speedtest.py
@@ -1,7 +1,6 @@
 import unittest
 import unittest.mock
 
-import ping3
 import pytest
 from pytest_mock import MockerFixture
 


### PR DESCRIPTION
Hi Dylann,

I think it's a good idea to run a small request before starting the actual speedtest, so that keep alive will keep the connection open and we time the time it takes to transfer data, instead of including the connection open time.

Additionally I've changed the HTTP Latency to use `Connection: Close`, so that it does include connection times.

I've also changed the `PING_HOST` to Cloudflare's `1.1.1.1` instead of Google, so that we're staying with Cloudflare.

Thanks,
Steve