### PR TITLE
Fix for 403 error on /meta endpoint

### DIFF
--- a/speedtest_cloudflare_cli/core/speedtest.py
+++ b/speedtest_cloudflare_cli/core/speedtest.py
@@ -29,7 +29,11 @@ PING_TIMEOUT = 3
 
 @functools.cache
 def client() -> httpx.Client:
-    return httpx.Client(headers={"Connection": "Keep-Alive"}, timeout=None)  # noqa: S113
+    headers = {
+        "Connection": "Keep-Alive",
+        "Referer": "https://speed.cloudflare.com/"
+    }
+    return httpx.Client(headers=headers, timeout=None)  # noqa: S113
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Add the Referer header to the client request to fix the following error:

```
Traceback (most recent call last):
  File "/usr/local/bin/speedtest-cli", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/usr/local/lib/python3.13/site-packages/click/core.py", line 1485, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/rich_click/rich_command.py", line 216, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.13/site-packages/click/core.py", line 1269, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/click/core.py", line 824, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.13/site-packages/speedtest_cloudflare_cli/main.py", line 110, in main
    "metadata": speedtester.metadata.__dict__,
                ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/speedtest_cloudflare_cli/core/speedtest.py", line 182, in metadata
    return metadata.Metadata.model_validate(client().get(f"{self.url}/meta").json())
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/pydantic/main.py", line 716, in model_validate
    return cls.__pydantic_validator__.validate_python(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        obj,
        ^^^^
    ...<5 lines>...
        by_name=by_name,
        ^^^^^^^^^^^^^^^^
    )
    ^
pydantic_core._pydantic_core.ValidationError: 9 validation errors for Metadata
hostname
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
clientIp
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
httpProtocol
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
asn
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
asOrganization
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
colo
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
country
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
latitude
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
longitude
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
```